### PR TITLE
P-value adjustment and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,15 @@
 language: python
 python:
     - "2.7"
+before_install:
+    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+    - chmod +x miniconda.sh
+    - ./miniconda.sh -b
+    - export PATH=/home/travis/miniconda/bin:$PATH
+    - conda update --yes conda
 install:
-    - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy
+    - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy
+    - pip install scipy
 script:
     - cd DevelopingRelease/WinnowDevel/Tests
     - python winnowdevel_test_suite.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: python
 python:
     - "2.7"
-before_install:
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - conda update --yes conda
-    - sudo rm -rf /dev/shm
-    - sudo ln -s /run/shm /dev/shm
 install:
-    - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy
-    - pip install scipy
+    - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy
 script:
     - cd DevelopingRelease/WinnowDevel/Tests
-    - ls
     - python winnowdevel_test_suite.py

--- a/DevelopingRelease/WinnowDevel/Tests/adjustments_unittest.py
+++ b/DevelopingRelease/WinnowDevel/Tests/adjustments_unittest.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append(os.getcwd()[:os.getcwd().index('DevelopingRelease')])
 from DevelopingRelease.WinnowDevel import adjustments
 
+
 class AdjustmentsTest(unittest.TestCase):
     def test_fdr_bh(self):
         test1 = [0.012, 0.033, 0.212, 0.9, 0.98, 0.001, 0.999, 0.0003, 0.00001]

--- a/DevelopingRelease/WinnowDevel/Tests/adjustments_unittest.py
+++ b/DevelopingRelease/WinnowDevel/Tests/adjustments_unittest.py
@@ -1,0 +1,23 @@
+import unittest
+import os
+import sys
+sys.path.append(os.getcwd()[:os.getcwd().index('DevelopingRelease')])
+from DevelopingRelease.WinnowDevel import adjustments
+
+class AdjustmentsTest(unittest.TestCase):
+    def test_fdr_bh(self):
+        test1 = [0.012, 0.033, 0.212, 0.9, 0.98, 0.001, 0.999, 0.0003, 0.00001]
+        results1 = [0.027, 0.05940000000000001, 0.318, 0.999, 0.999, 0.0030000000000000005, 0.999,
+                    0.0013499999999999999, 9e-05]
+        test2 = [0.010, 0.013, 0.014, 0.190, 0.350, 0.500, 0.630, 0.670, 0.750, 0.810]
+        results2 = [0.04666666666666667, 0.04666666666666667, 0.04666666666666667, 0.475, 0.7, 0.8100000000000002,
+                    0.8100000000000002, 0.8100000000000002, 0.8100000000000002, 0.8100000000000002]
+        self.assertEquals(adjustments.fdr_bh(test1), results1)
+        self.assertEquals(adjustments.fdr_bh(test2), results2)
+
+
+def get_test_suite():
+    return unittest.TestLoader().loadTestsFromTestCase(AdjustmentsTest)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/DevelopingRelease/WinnowDevel/Tests/adjustments_unittest.py
+++ b/DevelopingRelease/WinnowDevel/Tests/adjustments_unittest.py
@@ -13,8 +13,8 @@ class AdjustmentsTest(unittest.TestCase):
         test2 = [0.010, 0.013, 0.014, 0.190, 0.350, 0.500, 0.630, 0.670, 0.750, 0.810]
         results2 = [0.04666666666666667, 0.04666666666666667, 0.04666666666666667, 0.475, 0.7, 0.8100000000000002,
                     0.8100000000000002, 0.8100000000000002, 0.8100000000000002, 0.8100000000000002]
-        self.assertEquals(adjustments.fdr_bh(test1), results1)
-        self.assertEquals(adjustments.fdr_bh(test2), results2)
+        self.assertAlmostEquals(adjustments.fdr_bh(test1), results1)
+        self.assertAlmostEquals(adjustments.fdr_bh(test2), results2)
 
 
 def get_test_suite():

--- a/DevelopingRelease/WinnowDevel/Tests/winnow_unittest.py
+++ b/DevelopingRelease/WinnowDevel/Tests/winnow_unittest.py
@@ -46,9 +46,9 @@ class WinnowTest(unittest.TestCase):
         self.win.load_kt()
         gen = self.win.do_analysis()
         a = gen.next()[1]
-        self.assertEqual(a,
-                         [0.058961209687231286, 0.18211782935394086, 0.026434018860365737, 0.00069875735311017147,
-                          0.43427678571428574, 0, 384, 2816, 35, 0.0, 0.12, 0.1295208655332303, 0.0, 0.88, 0.0, -0.12])
+        self.assertEqual(format_float(a),
+                         [0.05896121, 0.18211783, 0.02643402, 0.00069876, 0.43427679, 0.00000, 384.00000, 2816.00000, 35.00000,
+                          0.00000, 0.12000, 0.12952087, 0.00000, 0.88000, 0.00000, -0.12000])
         gen.close()
 
     def test_do_gwas(self):
@@ -57,10 +57,11 @@ class WinnowTest(unittest.TestCase):
         score_column = (0.003, 0.65, 0.004, 0.006, 0.078, 0.003, 0.0001, 0.513, 0.421, 0.0081, 0.043, 0.98)
         self.win.beta_true_false = (1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1)
         beta_column = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
-        self.assertEqual(self.win.do_gwas(score_column, beta_column)[1],
-                         [47.083333333333336, 5.916666666666667, 0.024482659157056445, 0.00059940059940059973,
-                          0.56944444444444442, 4, 3, 3, 2, 0.6666666666666666, 0.5, 0.4166666666666667,
-                          0.6666666666666666, 0.5, 0.5714285714285714, 0.16666666666666652])
+        a = format_float(self.win.do_gwas(score_column, beta_column)[1])
+        self.assertEqual(a,
+                         [47.08333333, 5.91666667, 0.02448266, 0.0005994,
+                          0.56944444, 4, 3, 3, 2, 0.66666667, 0.5, 0.41666667,
+                          0.66666667, 0.5, 0.57142857, 0.16666667])
 
     def test_data_to_list(self):
         kt_file = loadKT(self.args['truth'], self.args['kt_type_separ'])
@@ -70,6 +71,17 @@ class WinnowTest(unittest.TestCase):
                           'IDP755', 'mmp49', 'cdo1081a', 'gpm330', 'gpm83b', 'gpm767', 'asg31', 'npi415', 'AY108650',
                           'ufg31', 'ufg33', 'ufg32', 'ufg34', 'IDP4043', 'gpm495', 'bnlg1014', 'umc1363a'])
 
+def format_float(float_list):
+    '''
+    Truncuates floats to 5 decimal places
+
+    :param float_list:
+    :return: a list of float truncuated to 5 decimal places
+    '''
+    return_list = list()
+    for each in float_list:
+        return_list.append(float('%.8f' % each))
+    return return_list
 
 def get_test_suite():
     """

--- a/DevelopingRelease/WinnowDevel/Tests/winnowdevel_test_suite.py
+++ b/DevelopingRelease/WinnowDevel/Tests/winnowdevel_test_suite.py
@@ -14,10 +14,12 @@ def main():
 
     """
     test_suite = unittest.TestSuite()
+
     # Test suite's to add
     test_suite.addTests(winnow_unittest.get_test_suite())
     test_suite.addTests(performetrics_unittest.get_test_suite())
     test_suite.addTests(adjustments_unittest.get_test_suite())
+
     # Runs tests
     unittest.TextTestRunner(verbosity=2).run(test_suite)
 

--- a/DevelopingRelease/WinnowDevel/Tests/winnowdevel_test_suite.py
+++ b/DevelopingRelease/WinnowDevel/Tests/winnowdevel_test_suite.py
@@ -5,6 +5,7 @@ Class for consolidating unittests for the winnow folder
 import unittest
 import winnow_unittest
 import performetrics_unittest
+import adjustments_unittest
 
 
 def main():
@@ -16,6 +17,7 @@ def main():
     # Test suite's to add
     test_suite.addTests(winnow_unittest.get_test_suite())
     test_suite.addTests(performetrics_unittest.get_test_suite())
+    test_suite.addTests(adjustments_unittest.get_test_suite())
     # Runs tests
     unittest.TextTestRunner(verbosity=2).run(test_suite)
 

--- a/DevelopingRelease/WinnowDevel/adjustments.py
+++ b/DevelopingRelease/WinnowDevel/adjustments.py
@@ -1,0 +1,43 @@
+def fdr_bh(score_col):
+    """
+    Benjamini-Hochberg FDR Method
+
+    :param score_col: unadjusted list of p-values
+    :return: list of adjusted p-values using the Benjamini-Hochberg FDR method
+    """
+    # List for p-vals in order from largest to smallest
+    ordered_scores = list()
+    # Copy of list of p-vals so the original is not modified
+    score_col_copy = list(score_col)
+    # List of adjusted p-vals in original order to be returned
+    new_pval = [None] * len(score_col)
+    # Copies the original list of p-vals into score_col_copy as a tuple (p, index(p)) so we can save the original order
+    for each in score_col_copy:
+        ordered_scores.append((each, score_col_copy.index(each)))
+        # Removes each p-val from the copy list to ensure that indexes are accurate in case of duplicate p-cals
+        score_col_copy[score_col_copy.index(each)] = None
+    # Sorts p-vals smallest to largest, then reverses so they are ordered largest to smallest
+    ordered_scores.sort()
+    ordered_scores.reverse()
+    # Solves for the adjusted p-val of the first (largest) original p-val
+    adjusted = len(ordered_scores)*ordered_scores[0][0]/len(ordered_scores)
+    # Iterates through all ordered p-vals, sets val to the minimum of the previous adjustment and current adjustment
+    for each in ordered_scores:
+        val = min(adjusted, float(len(ordered_scores)) * float(each[0]) /
+                  float(len(ordered_scores) - ordered_scores.index(each)))
+        # Sets the index of new_pval(from the tuple in ordered_scores) to the adjusted p-val
+        new_pval[each[1]] = val
+        # Updates the adjusted value so the minimum function will work on the next iteration
+        adjusted = val
+    # Returns the list of adjusted p-vals in the original order
+    return new_pval
+
+
+if __name__ == '__main__':
+    # Example from "Notes on Bonferroni-Holm method"
+    t1 = [0.012, 0.033, 0.212, 0.9, 0.98, 0.001, 0.999, 0.0003, 0.00001]
+    print fdr_bh(t1)
+
+    # Example from "Nov 12 Lecture"
+    t2 = [0.010, 0.013, 0.014, 0.190, 0.350, 0.500, 0.630, 0.670, 0.750, 0.810]
+    print fdr_bh(t2)

--- a/DevelopingRelease/WinnowDevel/commandline.py
+++ b/DevelopingRelease/WinnowDevel/commandline.py
@@ -38,6 +38,7 @@ def usage():
 	print "--seper or -s to specify either whitespace or comma"
 	print "--kttype or -k to specify the type of known-truth file for --class (either OTE or FGS)"
 	print "--kttypeseper or -r to specify delimination in known-truth file"
+	print "--pvaladjust or -p to specify the type of P-value adjustment"
 	print "--help or -h to see help menu\n\n"
 
 
@@ -45,9 +46,9 @@ def checkArgs():
 	"""Checks for arguments at beginning of the execution of the main function"""
 
 	try:
-		opts, args = getopt.getopt(sys.argv[1:], shortopts="vhpa:F:C:S:P:b:y:f:t:s:k:r:", longopts=["verbose", "help", 
+		opts, args = getopt.getopt(sys.argv[1:], shortopts="vhpa:F:C:S:P:b:y:f:t:s:k:r:p:", longopts=["verbose", "help",
 			"analysis=", "Folder=", "Class=", "Snp=", "Score=", "beta=", "filename=", "threshold=", "seper=", "kttype=",
-			"kttypeseper=", "severity="])
+			"kttypeseper=", "pvaladjust="])
 
 	except getopt.GetoptError as err:
 		print(err)
@@ -72,6 +73,7 @@ def checkArgs():
 	# file type lists every SNP with their effects. Both file formats can be arranged with either two rows or two columns.
 	kttypeseper = "whitespace"
 	# Similar to input data separation, the known-truth file has two options: whitespace or comma
+	pvaladjustment = None
         
 	"""Looping through command-line arguments to replace and/or create initialized values"""
 	for o in opts:
@@ -131,6 +133,10 @@ def checkArgs():
 			severity = float(o[1])
 			if verbose:
 				print "Severity ratio is specified at", severity
+		if o[0] in ("--pvaladjust", "-p"):
+			pvaladjustment = str(o[1])
+			if verbose:
+				print "P-value adjustment is set as", pvaladjustment
 
 	"""Check to see if needed variables are defined"""
 	try:
@@ -173,7 +179,8 @@ def checkArgs():
 	except NameError:
 		severity = None
 
-	return folder, analysis, truth, snp, score, beta, filename, threshold, seper, kttype, kttypeseper, severity
+	return folder, analysis, truth, snp, score, beta, filename, threshold, seper, kttype, kttypeseper, \
+		   severity, pvaladjustment
 if __name__ == "__main__":
     import doctest
     doctest.testmod()

--- a/DevelopingRelease/WinnowDevel/fileimport.py
+++ b/DevelopingRelease/WinnowDevel/fileimport.py
@@ -68,3 +68,22 @@ def writeCSV(filename, keepToWrite, method="wb", exportDelimiter=","):
 		for item in keepToWrite[1]:
 			currentRow.append(item)
 		openFileWriter.writerow(currentRow)
+
+def writeSettings(datafiles, winnowargs):
+	a = winnowargs['analysis']
+	if winnowargs['beta'] is not None:
+		a += ' with beta'
+	else:
+		a += ' without beta'
+	with open(winnowargs['filename'] +"_settings.txt", 'wb') as openFile:
+		openFileWriter = csv.writer(openFile, delimiter='\t')
+		openFileWriter.writerow(('Data Files', 'Truth File', 'Results File', 'Analysis Type', 'KT Type', 'Threshold'))
+		first_pass = True
+		for each in datafiles:
+			if first_pass:
+				openFileWriter.writerow((each, winnowargs['truth'], winnowargs['filename']+'.txt', a,
+										 winnowargs['kt_type'], winnowargs['threshold']))
+				first_pass = False
+			else:
+				openFileWriter.writerow((each, '', '', '', ''))
+

--- a/DevelopingRelease/WinnowDevel/fileimport.py
+++ b/DevelopingRelease/WinnowDevel/fileimport.py
@@ -8,82 +8,93 @@ import csv
 
 
 def getList(folder):
-	"""
-	Returns the complete location of the folder with the aggregated outputs
+    """
+    Returns the complete location of the folder with the aggregated outputs
 
-	:param folder: folder to get the location of
-	:return: the complete folder location
-	"""
-	return os.listdir(folder)
-    
+    :param folder: folder to get the location of
+    :return: the complete folder location
+    """
+    return os.listdir(folder)
+
 
 def loadFile(folder, thisFile, seper):
-	"""
-	Reads each GWAS output from a folder
+    """
+    Reads each GWAS output from a folder
 
-	:param folder: folder to load GWAS from
-	:param thisFile: file to read
-	:param seper: how the data is separated
-	:return: the GWAS data of the file
-	"""
-	return data.Data(folder + "/" + thisFile, seper, skiprow=False)
+    :param folder: folder to load GWAS from
+    :param thisFile: file to read
+    :param seper: how the data is separated
+    :return: the GWAS data of the file
+    """
+    return data.Data(folder + "/" + thisFile, seper, skiprow=False)
+
 
 def loadKT(thisFile, seper):
-	"""
-	Reads the SNPs and effect sizes from the known-truth file
+    """
+    Reads the SNPs and effect sizes from the known-truth file
 
-	:param thisFile: file to read
-	:param seper: how the data is separated
-	:return: the known-truth data of the file
-	"""
-	return data.Data(thisFile, seper, skiprow=True)
+    :param thisFile: file to read
+    :param seper: how the data is separated
+    :return: the known-truth data of the file
+    """
+    return data.Data(thisFile, seper, skiprow=True)
+
 
 def trueFalse(currentSnp, ktSnps):
-	"""
-	Defines the known truth list
+    """
+    Defines the known truth list
 
-	:param currentSnp: current SNP
-	:param ktSnps: known-truth SNPs
-	:return: True is the current SNP is in the known-truth SNPs
-	"""
-	if currentSnp in ktSnps:
-		return True
-	else:
-		return False
+    :param currentSnp: current SNP
+    :param ktSnps: known-truth SNPs
+    :return: True is the current SNP is in the known-truth SNPs
+    """
+    if currentSnp in ktSnps:
+        return True
+    else:
+        return False
+
 
 def writeCSV(filename, keepToWrite, method="wb", exportDelimiter=","):
-	"""
-	Writes the Winnow output file once analysis is complete
+    """
+    Writes the Winnow output file once analysis is complete
 
-	:param filename: file name to save as
-	:param keepToWrite: data to write
-	:param method: writing method
-	:param exportDelimiter: how data is separated
-	"""
-	with open(filename + ".txt", method) as openFile:
-		openFileWriter = csv.writer(openFile, delimiter=exportDelimiter)
-		if method == "wb":
-			openFileWriter.writerow(keepToWrite[0])
-		currentRow = list()
-		for item in keepToWrite[1]:
-			currentRow.append(item)
-		openFileWriter.writerow(currentRow)
+    :param filename: file name to save as
+    :param keepToWrite: data to write
+    :param method: writing method
+    :param exportDelimiter: how data is separated
+    """
+    with open(filename + ".txt", method) as openFile:
+        openFileWriter = csv.writer(openFile, delimiter=exportDelimiter)
+        if method == "wb":
+            openFileWriter.writerow(keepToWrite[0])
+        currentRow = list()
+        for item in keepToWrite[1]:
+            currentRow.append(item)
+        openFileWriter.writerow(currentRow)
+
 
 def writeSettings(datafiles, winnowargs):
-	a = winnowargs['analysis']
-	if winnowargs['beta'] is not None:
-		a += ' with beta'
-	else:
-		a += ' without beta'
-	with open(winnowargs['filename'] +"_settings.txt", 'wb') as openFile:
-		openFileWriter = csv.writer(openFile, delimiter='\t')
-		openFileWriter.writerow(('Data Files', 'Truth File', 'Results File', 'Analysis Type', 'KT Type', 'Threshold'))
-		first_pass = True
-		for each in datafiles:
-			if first_pass:
-				openFileWriter.writerow((each, winnowargs['truth'], winnowargs['filename']+'.txt', a,
-										 winnowargs['kt_type'], winnowargs['threshold']))
-				first_pass = False
-			else:
-				openFileWriter.writerow((each, '', '', '', ''))
+    """
+    Saves a settings file with parameters used in Winnow
 
+    :param datafiles: list of files containing data for analysis
+    :param winnowargs: dictionary of runtime arguments used in Winnow
+    :return: saves a txt file with the given filename that is appended with _settings containing the list of data files,
+    the truth and results file, the type of analysis, the type of known truth, and the threshold.
+    """
+    a = winnowargs['analysis']
+    if winnowargs['beta'] is not None:
+        a += ' with beta'
+    else:
+        a += ' without beta'
+    with open(winnowargs['filename'] + "_settings.txt", 'wb') as openFile:
+        openFileWriter = csv.writer(openFile, delimiter='\t')
+        openFileWriter.writerow(('Data Files', 'Truth File', 'Results File', 'Analysis Type', 'KT Type', 'Threshold'))
+        first_pass = True
+        for each in datafiles:
+            if first_pass:
+                openFileWriter.writerow((each, winnowargs['truth'], winnowargs['filename'] + '.txt', a,
+                                         winnowargs['kt_type'], winnowargs['threshold']))
+                first_pass = False
+            else:
+                openFileWriter.writerow((each, '', '', '', ''))

--- a/DevelopingRelease/WinnowDevel/fileimport.py
+++ b/DevelopingRelease/WinnowDevel/fileimport.py
@@ -73,28 +73,22 @@ def writeCSV(filename, keepToWrite, method="wb", exportDelimiter=","):
         openFileWriter.writerow(currentRow)
 
 
-def writeSettings(datafiles, winnowargs):
+def writeSettings(winnowargs):
     """
     Saves a settings file with parameters used in Winnow
 
-    :param datafiles: list of files containing data for analysis
     :param winnowargs: dictionary of runtime arguments used in Winnow
     :return: saves a txt file with the given filename that is appended with _settings containing the list of data files,
     the truth and results file, the type of analysis, the type of known truth, and the threshold.
     """
     a = winnowargs['analysis']
     if winnowargs['beta'] is not None:
-        a += ' with beta'
+        a += 'WithBeta'
     else:
-        a += ' without beta'
-    with open(winnowargs['filename'] + "_settings.txt", 'wb') as openFile:
+        a += 'WithoutBeta'
+    with open(winnowargs['filename'] + "_parameters.txt", 'wb') as openFile:
         openFileWriter = csv.writer(openFile, delimiter='\t')
-        openFileWriter.writerow(('Data Files', 'Truth File', 'Results File', 'Analysis Type', 'KT Type', 'Threshold'))
-        first_pass = True
-        for each in datafiles:
-            if first_pass:
-                openFileWriter.writerow((each, winnowargs['truth'], winnowargs['filename'] + '.txt', a,
-                                         winnowargs['kt_type'], winnowargs['threshold']))
-                first_pass = False
-            else:
-                openFileWriter.writerow((each, '', '', '', ''))
+        openFileWriter.writerow(('Output File: ', winnowargs['filename']))
+        openFileWriter.writerow(('Analysis Type: ', a))
+        openFileWriter.writerow(('KT Type: ', winnowargs['kt_type']))
+        openFileWriter.writerow(('Threshold: ', winnowargs['threshold']))

--- a/DevelopingRelease/WinnowDevel/winnow.py
+++ b/DevelopingRelease/WinnowDevel/winnow.py
@@ -139,8 +139,7 @@ class Winnow:
             return gwasWithBeta(beta_column, self.beta_true_false, self.snp_true_false, score_column, threshold)
 
     def save_settings(self):
-        data_files = checkList(getList(self.args_dict['folder']))
-        writeSettings(data_files, self.args_dict)
+        writeSettings(self.args_dict)
 
 
 def initialize():

--- a/DevelopingRelease/WinnowDevel/winnow.py
+++ b/DevelopingRelease/WinnowDevel/winnow.py
@@ -81,11 +81,13 @@ class Winnow:
         """
         acquired_data = loadFile(self.args_dict['folder'], data_file, self.args_dict['separ'])
         score_column = data_to_list(acquired_data, 1, acquired_data.header.index(self.args_dict['score']), True)
+        adjusted_score_column = self.adjust_score(score_column)
+        self.save_adjust_score(data_file, score_column, adjusted_score_column)
         if self.args_dict['beta'] is not None:
             beta_column = data_to_list(acquired_data, 1, acquired_data.header.index(self.args_dict['beta']), True)
-            return self.adjust_score(score_column), beta_column
+            return adjusted_score_column, beta_column
         else:
-            return score_column
+            return adjusted_score_column
 
     def do_analysis(self):
         """
@@ -155,6 +157,27 @@ class Winnow:
             print 'Currently only BH (Benjamini-Hochberg) is supported, the original P-values will be used'
             return score
         pass
+
+    def save_adjust_score(self, data, score, adjusted):
+        """
+        Saves the file name, p-value, and adjusted p-value
+
+        :param data: the data file
+        :param score: the list of p-values
+        :param adjusted: the list of adjusted p-values
+        :return: saves a text file in the format file, p-value, adjusted p-value if adjustments has been selected
+        """
+        if 'pvaladjust' in self.args_dict.keys():
+            try:
+                with open(self.args_dict['filename'] + '_adjustments.txt') as f:
+                    f.close()
+                    with open(self.args_dict['filename'] + '_adjustments.txt', 'a') as a:
+                        for (x, y) in zip(score, adjusted):
+                            a.write('\n' + data + '\t' + str(x) + '\t' + str(y))
+            except IOError:
+                with open(self.args_dict['filename'] + '_adjustments.txt', 'w') as f:
+                    f.write('File Name \tP-Value \tP-Value Adjusted')
+                self.save_adjust_score(data, score, adjusted)
 
     def save_settings(self):
         """

--- a/DevelopingRelease/WinnowDevel/winnow.py
+++ b/DevelopingRelease/WinnowDevel/winnow.py
@@ -40,6 +40,7 @@ class Winnow:
         given at runtime, separated by the given delimiter
         """
         app_output_list = checkList(getList(self.args_dict['folder']))
+        print app_output_list[0]
         kt_file = loadKT(self.args_dict['truth'], self.args_dict['kt_type_separ'])
         acquired_data = loadFile(self.args_dict['folder'], app_output_list[0], self.args_dict['separ'])
         snp_column = data_to_list(acquired_data, 1, acquired_data.header.index(self.args_dict['snp']))

--- a/DevelopingRelease/WinnowDevel/winnow.py
+++ b/DevelopingRelease/WinnowDevel/winnow.py
@@ -5,7 +5,7 @@
 
 """ Dependencies """
 from commandline import initializeGraphics, checkArgs
-from fileimport import getList, loadKT, loadFile, trueFalse, writeCSV
+from fileimport import getList, loadKT, loadFile, trueFalse, writeCSV, writeSettings
 from checkhidden import checkList
 from gwas import gwasWithBeta, gwasWithoutBeta
 
@@ -138,6 +138,10 @@ class Winnow:
         else:
             return gwasWithBeta(beta_column, self.beta_true_false, self.snp_true_false, score_column, threshold)
 
+    def save_settings(self):
+        data_files = checkList(getList(self.args_dict['folder']))
+        writeSettings(data_files, self.args_dict)
+
 
 def initialize():
     """
@@ -146,8 +150,8 @@ def initialize():
     :return: a dictionary of the runtime parameters
     """
     initializeGraphics()
-    folder, analysis, truth, snp, score, beta, filename, threshold, separ, kt_type,\
-        kt_type_separ, severity = checkArgs()
+    folder, analysis, truth, snp, score, beta, filename, threshold, separ, kt_type, \
+    kt_type_separ, severity = checkArgs()
     args = {'folder': folder, 'analysis': analysis, 'truth': truth, 'snp': snp, 'score': score, 'beta': beta,
             'filename': filename, 'threshold': threshold, 'separ': separ, 'kt_type': kt_type,
             'kt_type_separ': kt_type_separ}
@@ -183,6 +187,7 @@ def main():
     w = Winnow(args)
     w.load_kt()
     w.write_to_file(w.do_analysis())
+    w.save_settings()
 
 
 if __name__ == "__main__":

--- a/DevelopingRelease/WinnowDevel/winnow.py
+++ b/DevelopingRelease/WinnowDevel/winnow.py
@@ -95,8 +95,6 @@ class Winnow:
         results of the analysis with this data
         """
         app_output_list = sorted(checkList(getList(self.args_dict['folder'])))
-        print '\n'
-        print app_output_list
         for each in app_output_list:
             if self.args_dict['beta'] is not None:
                 score_column, beta_column = self.load_data(each)

--- a/DevelopingRelease/WinnowDevel/winnow.py
+++ b/DevelopingRelease/WinnowDevel/winnow.py
@@ -40,7 +40,7 @@ class Winnow:
         given at runtime, separated by the given delimiter
         """
         app_output_list = checkList(getList(self.args_dict['folder']))
-        print app_output_list[0]
+        print app_output_list
         kt_file = loadKT(self.args_dict['truth'], self.args_dict['kt_type_separ'])
         acquired_data = loadFile(self.args_dict['folder'], app_output_list[0], self.args_dict['separ'])
         snp_column = data_to_list(acquired_data, 1, acquired_data.header.index(self.args_dict['snp']))

--- a/DevelopingRelease/WinnowDevel/winnow.py
+++ b/DevelopingRelease/WinnowDevel/winnow.py
@@ -58,7 +58,7 @@ class Winnow:
         :param snp_col: the column number that the SNPs are listed in
         :param kt_snp: list of known truth SNPs
         :param kt_beta: list of known truth betas
-        :return: Stores the float representation of betas as booleans in the instance variable beta_true_false
+        :return: Stores the float representation of betas in the instance variable beta_true_false
         """
         if self.args_dict['beta'] is not None:
             count = 0

--- a/DevelopingRelease/WinnowDevel/winnow.py
+++ b/DevelopingRelease/WinnowDevel/winnow.py
@@ -40,7 +40,6 @@ class Winnow:
         given at runtime, separated by the given delimiter
         """
         app_output_list = checkList(getList(self.args_dict['folder']))
-        print app_output_list
         kt_file = loadKT(self.args_dict['truth'], self.args_dict['kt_type_separ'])
         acquired_data = loadFile(self.args_dict['folder'], app_output_list[0], self.args_dict['separ'])
         snp_column = data_to_list(acquired_data, 1, acquired_data.header.index(self.args_dict['snp']))
@@ -95,7 +94,9 @@ class Winnow:
         :return: loads all files from the folder given at runtime, parses data with the load_data function, returns the
         results of the analysis with this data
         """
-        app_output_list = checkList(getList(self.args_dict['folder']))
+        app_output_list = sorted(checkList(getList(self.args_dict['folder'])))
+        print '\n'
+        print app_output_list
         for each in app_output_list:
             if self.args_dict['beta'] is not None:
                 score_column, beta_column = self.load_data(each)


### PR DESCRIPTION
Added function to save parameters in winnow. Currently outputs a file with _parameters appended to the given file name and lists the used files, the type of analysis, the type of known truth, and the threshold.
Rounded unittests in winnow so unittests run of different machines - Travis CI in particular
Changed the Travis CI yml file in order to use their container based server rather than the legacy server.
Added FDR BH adjustment function and the parameter and implementation to use it in winnow.
Added FDR BH unittests and added them to the winnow test suite.
Added method save_adjust_score to winnow in order to save the data file name, original p-value, and adjusted p-value for comparison.