### PR TITLE
Saving P-Values and Updated Unittests for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
     - "2.7"
+
 before_install:
 
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/DevelopingRelease/WinnowDevel/Tests/performetrics_unittest.py
+++ b/DevelopingRelease/WinnowDevel/Tests/performetrics_unittest.py
@@ -73,7 +73,7 @@ class PerformetricsTest(unittest.TestCase):
         snp_tf = [True, False, True, True, True, False, False, True, False, False, True, False]
         score = [0.003, 0.65, 0.004, 0.006, 0.078, 0.003, 0.0001, 0.513, 0.421, 0.0081, 0.043, 0.98]
         threshold = 0.05
-        self.assertEqual(performetrics.accuracy(snp_tf, threshold, score), 0.5833333333333333)
+        self.assertEqual(format_float(performetrics.accuracy(snp_tf, threshold, score)), 0.58333333)
 
     def test_sens(self):
         snp_tf = [True, False, True, True, True, False, False, True, False, False, True, False]
@@ -97,13 +97,24 @@ class PerformetricsTest(unittest.TestCase):
         snp_tf = [True, False, True, True, True, False, False, True, False, False, True, False]
         score = [0.003, 0.65, 0.004, 0.006, 0.078, 0.003, 0.0001, 0.513, 0.421, 0.0081, 0.043, 0.98]
         threshold = 0.05
-        self.assertEqual(performetrics.fdr(snp_tf, threshold, score), 0.4285714285714286)
+        self.assertEqual(format_float(performetrics.fdr(snp_tf, threshold, score)), 0.42857143)
 
     def test_youden(self):
         snp_tf = [True, False, True, True, True, False, False, True, False, False, True, False]
         score = [0.003, 0.65, 0.004, 0.006, 0.078, 0.003, 0.0001, 0.513, 0.421, 0.0081, 0.043, 0.98]
         threshold = 0.05
         self.assertEqual(performetrics.youden(snp_tf, threshold, score), 0.16666666666666652)
+
+
+def format_float(x):
+    """
+    Truncates floats to 5 decimal places
+
+    :param float_list:
+    :return: a list of float truncuated to 5 decimal places
+    """
+    return float('%.8f' % x)
+
 
 def get_test_suite():
     """

--- a/DevelopingRelease/WinnowDevel/Tests/winnow_unittest.py
+++ b/DevelopingRelease/WinnowDevel/Tests/winnow_unittest.py
@@ -13,7 +13,7 @@ class WinnowTest(unittest.TestCase):
     destination = os.getcwd()[:os.getcwd().index("Validate-Master")] + "Validate-Master/ExampleData/Winnow/results"
     args = {'folder': folder, 'analysis': 'GWAS', 'truth': ote, 'snp': 'SNP', 'score': 'P', 'beta': 'BETA',
             'filename': destination, 'threshold': 0.05, 'separ': 'whitespace', 'kt_type': 'OTE',
-            'kt_type_separ': 'whitespace', 'savep': False}
+            'kt_type_separ': 'whitespace', 'pvaladjust': False, 'savep': False}
 
     def test_load_ote(self):
         self.win = winnow.Winnow(self.args)
@@ -47,9 +47,8 @@ class WinnowTest(unittest.TestCase):
         gen = self.win.do_analysis()
         a = gen.next()[1]
         self.assertEqual(format_float(a),
-                         [0.05896121, 0.18211783, 0.02643402, 0.00069876, 0.43427679, 0.00000, 384.00000, 2816.00000,
-                          35.00000,
-                          0.00000, 0.12000, 0.12952087, 0.00000, 0.88000, 0.00000, -0.12000])
+                         [0.05896121, 0.18211783, -0.03838186, 0.43427679, 0, 384,
+                          2816, 35, 0.0, 0.12, 0.12952087, 0.87047913, 0.0, 0.88, 0.0, 1.0, -0.12])
         gen.close()
 
     def test_do_gwas(self):
@@ -60,9 +59,8 @@ class WinnowTest(unittest.TestCase):
         beta_column = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
         a = format_float(self.win.do_gwas(score_column, beta_column)[1])
         self.assertEqual(a,
-                         [47.08333333, 5.91666667, 0.02448266, 0.0005994,
-                          0.56944444, 4, 3, 3, 2, 0.66666667, 0.5, 0.41666667,
-                          0.66666667, 0.5, 0.57142857, 0.16666667])
+                         [47.08333333, 5.91666667, 0.16903085, 0.56944444, 4.0, 3.0, 3.0, 2.0, 0.66666667, 0.5,
+                          0.41666667, 0.58333333, 0.66666667, 0.5, 0.57142857, 0.42857143, 0.16666667])
 
     def test_data_to_list(self):
         kt_file = loadKT(self.args['truth'], self.args['kt_type_separ'])
@@ -74,12 +72,12 @@ class WinnowTest(unittest.TestCase):
 
 
 def format_float(float_list):
-    '''
-    Truncuates floats to 5 decimal places
+    """
+    Truncates floats to 5 decimal places
 
     :param float_list:
     :return: a list of float truncuated to 5 decimal places
-    '''
+    """
     return_list = list()
     for each in float_list:
         return_list.append(float('%.8f' % each))

--- a/DevelopingRelease/WinnowDevel/commandline.py
+++ b/DevelopingRelease/WinnowDevel/commandline.py
@@ -38,6 +38,7 @@ def usage():
 	print "--kttype or -k to specify the type of known-truth file for --class (either OTE or FGS)"
 	print "--kttypeseper or -r to specify delimination in known-truth file"
 	print "--pvaladjust or -p to specify the type of P-value adjustment"
+	print "--savep or -o to save P-values"
 	print "--help or -h to see help menu\n\n"
 
 
@@ -59,6 +60,7 @@ def checkArgs():
         parser.add_argument("-r", "--kttypeseper", choices=["comma", "whitespace", "tab"], nargs='?', default="whitespace", help="Specify delimitation in known-truth file")
 	parser.add_argument("-y", "--severity", type=float, default=None, nargs='?', help="Severity ratio used in the h-measure calculation (currently not available, can leave blank)")
 	parser.add_argument("-p", "--pvaladjust", default=None, nargs='?', choices=["BH"], help="Specify the type of p-value adjustment")
+	parser.add_argument("-o", "--savep", default=False, action="store_true", help="Saves P-values in a text file if specified")
 	args = parser.parse_args()
         
 	"""Change command line arguments into variables to pass along to the rest of the program"""
@@ -104,12 +106,15 @@ def checkArgs():
 	pvaladjust = args.pvaladjust
 	if verbose:
 	    print "P-value adjustment set as", pvaladjust
+	savep = args.savep
+	if verbose:
+		print "Saving P-values is set as", savep
 	
 	if pvaladjust not in ["BH"]:
 	    print 'Currently only BH (Benjamini-Hochberg) is supported, the original P-values will be used'
 
 	return folder, analysis, truth, snp, score, beta, filename, threshold, seper, kttype, kttypeseper, \
-		   severity, pvaladjust
+		   severity, pvaladjust, savep
 if __name__ == "__main__":
     import doctest
     doctest.testmod()

--- a/DevelopingRelease/WinnowDevel/winnow.py
+++ b/DevelopingRelease/WinnowDevel/winnow.py
@@ -81,8 +81,9 @@ class Winnow:
         """
         acquired_data = loadFile(self.args_dict['folder'], data_file, self.args_dict['separ'])
         score_column = data_to_list(acquired_data, 1, acquired_data.header.index(self.args_dict['score']), True)
+        snp_column = data_to_list(acquired_data, 1, acquired_data.header.index(self.args_dict['snp']))
         adjusted_score_column = self.adjust_score(score_column)
-        self.save_adjust_score(data_file, score_column, adjusted_score_column)
+        self.save_snp_score(snp_column, score_column, adjusted_score_column)
         if self.args_dict['beta'] is not None:
             beta_column = data_to_list(acquired_data, 1, acquired_data.header.index(self.args_dict['beta']), True)
             return adjusted_score_column, beta_column
@@ -148,7 +149,7 @@ class Winnow:
         :param score: the list of p-values to adjust
         :return: the list of adjusted p-values
         """
-        if self.args_dict['pvaladjust'] == None:
+        if self.args_dict['pvaladjust'] is None:
             return score
         elif self.args_dict['pvaladjust'] == 'BH':
             return fdr_bh(score)
@@ -157,26 +158,33 @@ class Winnow:
             return score
         pass
 
-    def save_adjust_score(self, data, score, adjusted):
+    def save_snp_score(self, snp, score, adjusted):
         """
-        Saves the file name, p-value, and adjusted p-value
+        Saves the file name, p-value, and adjusted p-value if set
 
         :param data: the data file
         :param score: the list of p-values
         :param adjusted: the list of adjusted p-values
         :return: saves a text file in the format file, p-value, adjusted p-value if adjustments has been selected
         """
-        if 'pvaladjust' in self.args_dict.keys():
+        if self.args_dict['savep']:
             try:
-                with open(self.args_dict['filename'] + '_adjustments.txt') as f:
+                with open(self.args_dict['filename'] + '_scores.txt') as f:
                     f.close()
-                    with open(self.args_dict['filename'] + '_adjustments.txt', 'a') as a:
-                        for (x, y) in zip(score, adjusted):
-                            a.write('\n' + data + '\t' + str(x) + '\t' + str(y))
+                    with open(self.args_dict['filename'] + '_scores.txt', 'a') as a:
+                        if self.args_dict['pvaladjust'] is not None:
+                            for (x, y, z) in zip(score, adjusted, snp):
+                                a.write('\n' + z + '\t' + str(x) + '\t' + str(y))
+                        else:
+                            for (x, z) in zip(score, snp):
+                                a.write('\n' + z + '\t' + str(x))
             except IOError:
-                with open(self.args_dict['filename'] + '_adjustments.txt', 'w') as f:
-                    f.write('File Name \tP-Value \tP-Value Adjusted')
-                self.save_adjust_score(data, score, adjusted)
+                with open(self.args_dict['filename'] + '_scores.txt', 'w') as f:
+                    if self.args_dict['pvaladjust'] is not None:
+                        f.write('SNP ID \tP-Value \tP-Value Adjusted')
+                    else:
+                        f.write('SNP ID \tP-Value')
+                self.save_snp_score(snp, score, adjusted)
 
     def save_settings(self):
         """
@@ -195,10 +203,10 @@ def initialize():
     """
     initializeGraphics()
     folder, analysis, truth, snp, score, beta, filename, threshold, separ, kt_type, \
-    kt_type_separ, severity, pvaladjust = checkArgs()
+    kt_type_separ, severity, pvaladjust, savep = checkArgs()
     args = {'folder': folder, 'analysis': analysis, 'truth': truth, 'snp': snp, 'score': score, 'beta': beta,
             'filename': filename, 'threshold': threshold, 'separ': separ, 'kt_type': kt_type,
-            'kt_type_separ': kt_type_separ, 'severity': severity, 'pvaladjust': pvaladjust}
+            'kt_type_separ': kt_type_separ, 'severity': severity, 'pvaladjust': pvaladjust, 'savep': savep}
     return args
 
 


### PR DESCRIPTION
Added function for saving P-values as SNP ID, P, Adjusted P (If applicable)
Updated new unittests to work with Travis CI rounding