### PR TITLE
Winnow Demonstrate Parameters

### DIFF
--- a/DevelopingRelease/DemonstrateDevel/DemoMPlot/R/Demonstrate.R
+++ b/DevelopingRelease/DemonstrateDevel/DemoMPlot/R/Demonstrate.R
@@ -3,6 +3,7 @@
 #' This function allows you to enter a directory including multiple Winnow output files and creating
 #' visualizations fromt the output.
 #' @param dir A character string: input the directory containing the text files you would like to use.
+#' @param settingsfile A character string: input the winnow .param file containing settings used. Default is NULL and is not required.
 #' @param make.AUC.plot Option to make a AUC by Population Structure and Heritability. Default set to TRUE
 #' @param AUC.plot.title A Character String: title of the AUC plot.
 #' Default set to "Mean AUC By Population Structure and Heritability"
@@ -21,10 +22,25 @@
 #' @examples
 #' demonstrate (dir="path")
 
-Demonstrate <- function(dir, make.AUC.plot=TRUE, AUC.plot.title="Mean AUC By Population Structure and Heritability",
-                        make.MAE.plot=TRUE, MAE.plot.title="Mean MAE By Population Structure and Heritability",herit.strings=list("_03_","_04_","_06_")
+Demonstrate <- function(dir, settingsfile=NULL, make.AUC.plot=TRUE, AUC.plot.title="Mean AUC By Population Structure and Heritability.pdf",
+                        make.MAE.plot=TRUE, MAE.plot.title="Mean MAE By Population Structure and Heritability.pdf",herit.strings=list("_03_","_04_","_06_")
                         ,herit.values=list(0.3,0.4,0.6),struct.strings=list("PheHasStruct","PheNPStruct"),struct.values=list(TRUE,FALSE)) {
-
+  if (!is.null(settingsfile)){
+    setwd(dir)
+    settings <- readLines(settingsfile)
+  }
+  writeSettings <- function(settings){
+    if (!is.null(settings)){
+      plot(0:10, type="n", xaxt="n", yaxt="n", bty="n", xlab="", ylab="")
+      text(font=2, 5, 8, "Winnow Settings:")
+      text(5, 7, settings[1])
+      text(5, 6, settings[2])
+      text(5, 5, settings[3])
+      if (!is.na(settings[4])){
+        text(5, 4, settings[4])
+      }
+    }
+  }
   makeFiles <- function(dir) {
 
     readFiles <- function(dir) {
@@ -80,6 +96,7 @@ Demonstrate <- function(dir, make.AUC.plot=TRUE, AUC.plot.title="Mean AUC By Pop
     pdf(file=AUC.plot.title)
     lineplot.CI(totalDataSet$Herit,totalDataSet$AUC,totalDataSet$Structure,main=AUC.plot.title,
                 xlab="Heritability",ylab="Mean AUC",trace.label="Pop. Structure")
+    writeSettings(settings)
     dev.off()
   }
 
@@ -87,6 +104,7 @@ Demonstrate <- function(dir, make.AUC.plot=TRUE, AUC.plot.title="Mean AUC By Pop
     pdf(file=MAE.plot.title)
     lineplot.CI(totalDataSet$Herit,totalDataSet$MAE,totalDataSet$Structure,main=MAE.plot.title,
                 xlab="Heritability",ylab="Mean MAE",trace.label="Pop. Structure")
+    writeSettings(settings)
     dev.off()
   }
 

--- a/DevelopingRelease/DemonstrateDevel/Tests/Dem2TestFiles/results.param
+++ b/DevelopingRelease/DemonstrateDevel/Tests/Dem2TestFiles/results.param
@@ -1,0 +1,3 @@
+Analysis Type:	GWASWithoutBeta
+KT Type:	OTE
+Threshold:	0.05

--- a/DevelopingRelease/DemonstrateDevel/Tests/DemTestFiles/results.param
+++ b/DevelopingRelease/DemonstrateDevel/Tests/DemTestFiles/results.param
@@ -1,0 +1,3 @@
+Analysis Type:	GWASWithoutBeta
+KT Type:	OTE
+Threshold:	0.05

--- a/DevelopingRelease/DemonstrateDevel/Tests/Demonstrate_unittest.py
+++ b/DevelopingRelease/DemonstrateDevel/Tests/Demonstrate_unittest.py
@@ -12,12 +12,12 @@ class DemonstrateTest(unittest.TestCase):
     def test_function(self):
         self.load_r()
         r_dem = robjects.globalenv['Demonstrate']
-        outputs = ['Mean AUC By Population Structure and Heritability',
-                   'Mean MAE By Population Structure and Heritability']
+        outputs = ['Mean AUC By Population Structure and Heritability.pdf',
+                   'Mean MAE By Population Structure and Heritability.pdf']
         for each in outputs:
             if os.path.isfile(self.testdir + '/' + each):
                 os.remove(self.testdir + '/' + each)
-        r_dem(self.testdir)
+        r_dem(self.testdir, "results.param")
         for each in outputs:
             self.assertTrue(os.path.isfile(self.testdir + '/' + each))
             self.assertTrue(os.path.getsize(self.testdir + '/' + each) > 0)

--- a/DevelopingRelease/DemonstrateDevel/Tests/demonstrate2_unittest.py
+++ b/DevelopingRelease/DemonstrateDevel/Tests/demonstrate2_unittest.py
@@ -15,15 +15,21 @@ class Dem2Test(unittest.TestCase):
         r_dem2(self.testdir)
         return_value = str(r_dem2(self.testdir))
         self.assertEquals(return_value, '[1] "Done!"\n')
+        outputnames = ['ComparisonTable.csv', 'TP Histograms.pdf', 'FP Histograms.pdf',
+                       'True Positives vs. False Positives.pdf', 'Plot of AUC by MAE.pdf']
+        for name in outputnames:
+            if os.path.isfile(self.testdir + '/' + name):
+                os.remove(self.testdir + '/' + name)
         
     def test_outputs(self):
         self.load_r()
         r_dem2 = robjects.globalenv['Demonstrate2']
-        outputnames = ['ComparisonTable.csv', 'TP Histograms.pdf', 'FP Histograms.pdf', 'True Positives vs. False Positives.pdf', 'Plot of AUC by MAE.pdf']
+        outputnames = ['ComparisonTable.csv', 'TP Histograms.pdf', 'FP Histograms.pdf',
+                       'True Positives vs. False Positives.pdf', 'Plot of AUC by MAE.pdf']
         for name in outputnames:
             if os.path.isfile(self.testdir + '/' + name):
                 os.remove(self.testdir + '/' + name)
-        r_dem2(self.testdir)
+        r_dem2(self.testdir, "results.param")
         for name in outputnames:
             self.assertTrue(os.path.isfile(self.testdir + '/' + name))
             self.assertTrue(os.path.getsize(self.testdir + '/' + name) > 0)

--- a/DevelopingRelease/SimulateDevel/Simulate.py
+++ b/DevelopingRelease/SimulateDevel/Simulate.py
@@ -272,6 +272,7 @@ def main():
 	format_data(filename, new_phenotypes)
 
 	print "\n\n"
+
 def format_data(f, pheno):
 	ped_file = open(f+'_genomes.ped')
 	new_file = open(f+'temp_genomes.ped', 'w')

--- a/DevelopingRelease/WinnowDevel/checkhidden.py
+++ b/DevelopingRelease/WinnowDevel/checkhidden.py
@@ -1,8 +1,8 @@
 """
 Functions to detect if something is meant to be isHidden.
 
-The main reason to use this function is in case some output folders carry a history file with them (for instance, .RHistory files)
-which would cause an error when read by the Winnow program.
+The main reason to use this function is in case some output folders carry a history file with them
+(for instance, .RHistory files) which would cause an error when read by the Winnow program.
 """
 
 

--- a/DevelopingRelease/WinnowDevel/commandline.py
+++ b/DevelopingRelease/WinnowDevel/commandline.py
@@ -31,7 +31,7 @@ def usage():
     print "--folder or -F to input folder of box results (required)"
     print "--class or -C to specify the known-truth file for used simulation (required)"
     print "--snp or -S to specify a string for the name of the SNP column in results file (required)"
-    print "--score or -P to specify a string for the name of the scoring column in results file (e.g., p-value; required)"
+    print "--score or -P to specify a string for the name of the scoring column in results file (e.g. p-value; required)"
     print "--beta or -b to specify a string for the name of the estimated SNP effect column in results file"
     print "--filename or -f to specify the desired filename for the Winnow output file"
     print "--threshold ir -t to specify a desired threshold for classification performetrics where necessary"
@@ -67,7 +67,7 @@ def checkArgs():
     parser.add_argument("-r", "--kttypeseper", choices=["comma", "whitespace", "tab"], nargs='?', default="whitespace",
                         help="Specify delimitation in known-truth file")
     parser.add_argument("-y", "--severity", type=float, default=None, nargs='?',
-                        help="Severity ratio used in the h-measure calculation (currently not available, can leave blank)")
+                        help="Severity ratio used in the h-measure calculation (currently not available)")
     parser.add_argument("-p", "--pvaladjust", default=None, nargs='?', choices=["BH"],
                         help="Specify the type of p-value adjustment")
     parser.add_argument("-o", "--savep", default=False, action="store_true",
@@ -107,7 +107,6 @@ def checkArgs():
         print "P-value adjustment is set as", pvaladjust
         if savep:
             print "Saving p-values"
-
     if pvaladjust not in ["BH"] and pvaladjust is not None:
         print 'Currently only BH (Benjamini-Hochberg) is supported, the original P-values will be used'
 

--- a/DevelopingRelease/WinnowDevel/fileimport.py
+++ b/DevelopingRelease/WinnowDevel/fileimport.py
@@ -63,7 +63,7 @@ def writeSettings(winnowargs):
         a += 'WithBeta'
     else:
         a += 'WithoutBeta'
-    with open(winnowargs['filename'] + "_parameters.txt", 'wb') as openFile:
+    with open(winnowargs['filename'] + "_.parameters", 'wb') as openFile:
         openFileWriter = csv.writer(openFile, delimiter='\t')
         openFileWriter.writerow(('Analysis Type: ', a))
         openFileWriter.writerow(('KT Type: ', winnowargs['kt_type']))

--- a/DevelopingRelease/WinnowDevel/winnow.py
+++ b/DevelopingRelease/WinnowDevel/winnow.py
@@ -239,6 +239,12 @@ def data_to_list(data_file, x, y, is_float=False):
 
 
 def verify_files(args):
+    """
+    Verifies that the KT file and input folders exist. If they do not, the program will terminate and alert the user
+    which file(s) are causing the problem.
+
+    :param args: arguments passed to winnow containing the file and folder names
+    """
     file_error = False
     error_string = "\n"
     if not os.path.isfile(args['truth']):

--- a/StampedeScripts/Winnow/winnow-0.7.json
+++ b/StampedeScripts/Winnow/winnow-0.7.json
@@ -32,7 +32,7 @@
       "details": {
         "label": "Known-truth file name",
         "description": "Specifies the \"known-truth\" file for the data group you are analyzing",
-        "attribute": "--Class",
+        "attribute": "--class",
         "showAttribute": true
       },
       "semantics": {
@@ -53,7 +53,7 @@
       "details": {
         "label": "Folder for collected results",
         "description": "The folder containing the aggregated GWAS results you wish to analyze",
-        "attribute": "--Folder",
+        "attribute": "--folder",
         "showAttribute": true
       },
       "semantics": {
@@ -74,7 +74,7 @@
       "details": {
         "label": "Name for the SNP column in input file",
         "description": "A name for the SNP column in the input file",
-        "attribute": "--SNP",
+        "attribute": "--snp",
         "showAttribute": true
       },
       "semantics": {
@@ -95,7 +95,7 @@
       "details": {
         "label": "Name for p-value column",
         "description": "Name for the p-value column in the input file (e.g. p-value)",
-        "attribute": "--Score",
+        "attribute": "--score",
         "showAttribute": true
       },
       "semantics": {


### PR DESCRIPTION
Added the option to add a .param file (from winnow) to Demonstrate and Demonstrate2. On plots that take up an entire page, the settings will be added to a new page. On the plots "True Positive by False Positives" and "Plot of AUC by MAE" the settings will be added above the legend. 

Changed winnow parameter output file from a .txt to a .parameter to work with Demonstrate. If they were a .txt file, demonstrate would expect them to contain data rather than parameters. The .parameter file can be open/edited as a text file. 