### PR TITLE
Update Travis CI to fix failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
     - R CMD INSTALL dichromat_2.0-0.tar.gz
     - wget https://cran.r-project.org/src/contrib/RColorBrewer_1.1-2.tar.gz
     - R CMD INSTALL RColorBrewer_1.1-2.tar.gz
-    - wget https://cran.r-project.org/src/contrib/scales_0.2.5.tar.gz
+    - wget https://cran.r-project.org/src/contrib/scales_0.3.0.tar.gz
     - R CMD INSTALL scales_0.2.5.tar.gz
     - wget https://cran.r-project.org/src/contrib/proto_0.3-10.tar.gz
     - R CMD INSTALL proto_0.3-10.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
     - wget https://cran.r-project.org/src/contrib/RColorBrewer_1.1-2.tar.gz
     - R CMD INSTALL RColorBrewer_1.1-2.tar.gz
     - wget https://cran.r-project.org/src/contrib/scales_0.3.0.tar.gz
-    - R CMD INSTALL scales_0.2.5.tar.gz
+    - R CMD INSTALL scales_0.3.0.tar.gz
     - wget https://cran.r-project.org/src/contrib/proto_0.3-10.tar.gz
     - R CMD INSTALL proto_0.3-10.tar.gz
     - wget https://cran.r-project.org/src/contrib/ggplot2_1.0.1.tar.gz


### PR DESCRIPTION
One of the needed R packages, scales, was updated. This caused the old link to break so Travis was getting hung up on it. Updated this link to the newest version of scales.